### PR TITLE
TASK: Add Earmark to Assistants

### DIFF
--- a/Classes/Domain/AssistantRecord.php
+++ b/Classes/Domain/AssistantRecord.php
@@ -56,4 +56,42 @@ final class AssistantRecord
             $response->fileIds,
         );
     }
+
+    public function withNamePrefix(string $prefix): self
+    {
+        return new self(
+            $this->id,
+            $this->model,
+            $prefix . $this->name,
+            $this->description,
+            $this->instructions,
+            $this->tools,
+            $this->metadata,
+            $this->selectedTools,
+            $this->selectedSourcesOfKnowledge,
+            $this->selectedInstructions,
+            $this->fileIds,
+        );
+    }
+
+    public function withoutNamePrefix(string $prefix): self
+    {
+        $name = $this->name;
+        if (str_starts_with($name, $prefix)){
+            $name = substr($name, strlen($prefix));
+        }
+        return new self(
+            $this->id,
+            $this->model,
+            $name,
+            $this->description,
+            $this->instructions,
+            $this->tools,
+            $this->metadata,
+            $this->selectedTools,
+            $this->selectedSourcesOfKnowledge,
+            $this->selectedInstructions,
+            $this->fileIds,
+        );
+    }
 }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,6 +1,7 @@
 Sitegeist:
   Chatterbox:
-    earmark: "Sitegeist.Chatterbox"
+    earmark: "Sitegeist-Chatterbox: "
+
     tools: []
     knowledge: []
     instructions:


### PR DESCRIPTION
Earmarks are settings and allow to only interact with assitants having the same name-prefix. This ensures live assistants will not interfere with dev or local assistants that are teached with possible different tools.

I choose the name prefix over metadata as this can be seen in the playgound aswell. 