### PR TITLE
TASK: Store metadata for messages in a cache to allow reloading of treads

### DIFF
--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -1,0 +1,6 @@
+Sitegeist_Chatterbox_MetaDataCache:
+  persistent: true
+  frontend: Neos\Cache\Frontend\VariableFrontend
+  backend: Neos\Cache\Backend\FileBackend
+  backendOptions:
+    defaultLifetime: 86400

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,0 +1,9 @@
+Sitegeist\Chatterbox\Controller\ChatController:
+  properties:
+    metaDataCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Sitegeist_Chatterbox_MetaDataCache


### PR DESCRIPTION
This is implemented inside the chat controller for simplicity as otherwise the whole assistant thingy would be affected badly.

The implementation relies on the getByTag method of the taggable CacheFrontend that returns all items having this tag with the id as key. That allows to assign the metadata to the keys without asking the cache for every item itself.