### PR TITLE
BUGFIX: Use .json instead of .jsonl as storage format for the source of knowledge

### DIFF
--- a/Classes/Domain/Knowledge/JsonlRecordCollection.php
+++ b/Classes/Domain/Knowledge/JsonlRecordCollection.php
@@ -35,7 +35,7 @@ final class JsonlRecordCollection implements \IteratorAggregate, \Countable, \St
 
     public function __toString(): string
     {
-        return implode("\n", array_map(
+        return '[' . "\n" . implode("\n", array_map(
             fn (JsonlRecord $record): string => \str_replace(
                 PHP_EOL,
                 "\\\\n",
@@ -45,6 +45,6 @@ final class JsonlRecordCollection implements \IteratorAggregate, \Countable, \St
                 )
             ),
             $this->items
-        ));
+        )) . "\n" . ']';
     }
 }

--- a/Classes/Domain/Knowledge/KnowledgeFilename.php
+++ b/Classes/Domain/Knowledge/KnowledgeFilename.php
@@ -10,7 +10,7 @@ use Sitegeist\Chatterbox\Domain\OrganizationDiscriminator;
 #[Flow\Proxy(false)]
 final class KnowledgeFilename
 {
-    private const FILE_ENDING = '.jsonl';
+    private const FILE_ENDING = '.json';
 
     public function __construct(
         public readonly KnowledgeSourceDiscriminator $knowledgeSourceDiscriminator,


### PR DESCRIPTION
Since open ai changed from "not officially allowing jsonl but working with it" to "throw an error when a jsonl is configured for retrieval" this is needed. 

Did not check the behavior regarding quotes yet.