### PR TITLE
Catch empty citation quotes

### DIFF
--- a/Classes/Domain/Knowledge/QuoteString.php
+++ b/Classes/Domain/Knowledge/QuoteString.php
@@ -40,4 +40,9 @@ final class QuoteString
 
         return '%' . $value . '%';
     }
+
+    public function isEmpty(): bool
+    {
+        return $this->value === '';
+    }
 }

--- a/Classes/Domain/Knowledge/SourceOfKnowledgeCollection.php
+++ b/Classes/Domain/Knowledge/SourceOfKnowledgeCollection.php
@@ -53,6 +53,9 @@ final class SourceOfKnowledgeCollection implements \IteratorAggregate, \Countabl
         foreach ($annotations as $annotation) {
             if ($annotation instanceof ThreadMessageResponseContentTextAnnotationFileCitationObject) {
                 $quoteString = QuoteString::fromFileCitationObject($annotation);
+                if ($quoteString->isEmpty()) {
+                    continue;
+                }
                 $databaseRecord = $databaseConnection->executeQuery(
                     'SELECT id, knowledge_source_discriminator FROM ' . Library::TABLE_NAME
                     . ' WHERE knowledge_source_discriminator IN (:knowledgeSourceDiscriminators)


### PR DESCRIPTION
Since OpenAI currently seems to be too lazy to add quote texts to quotes, we should just skip those